### PR TITLE
Update devspaces image to the latest version - v25.4.0

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
 components:
   - name: tooling-container
     container:
-      image: ghcr.io/ansible/ansible-devspaces@sha256:a28fa23d254ff1b3ae10b95a0812132148f141bda4516661e40d0c49c4ace200 # v24.10.2
+      image: ghcr.io/ansible/ansible-devspaces@sha256:7cf40941f4082f4afb171269214776bb5b0d859cc7793f9f51bfec95ed3074d2 # v25.4.0
       memoryRequest: 256M
       memoryLimit: 6Gi
       cpuRequest: 250m


### PR DESCRIPTION
Updates the devfile.yaml to pull the latest released image, [v25.4.0](https://github.com/ansible/ansible-dev-tools/pkgs/container/ansible-devspaces/387138783?tag=v25.4.0). 