### PR TITLE
devfile: align with OCP 4.20+ container-in-container (drop kubedock)

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -10,12 +10,9 @@ components:
       memoryLimit: 6Gi
       cpuRequest: 250m
       cpuLimit: 2000m
-      args: ['tail', '-f', '/dev/null']
       env:
         - name: 'ANSIBLE_COLLECTIONS_PATH'
           value: '~/.ansible/collections:/usr/share/ansible/collections:/projects/ansible-devspaces-demo/collections'
-        - name: 'KUBEDOCK_ENABLED'
-          value: "true"
 commands:
 
   - id: molecule-create


### PR DESCRIPTION
Remove KUBEDOCK_ENABLED and container args for OCP 4.20+ / Dev Spaces 3.25+ (user-namespace container-in-container). Image SHA left unchanged until next ansible-dev-tools release.

Made with [Cursor](https://cursor.com)