### PR TITLE
Update ansible-devspaces container image

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
 components:
   - name: tooling-container
     container:
-      image: ghcr.io/ansible/ansible-devspaces@sha256:7cf40941f4082f4afb171269214776bb5b0d859cc7793f9f51bfec95ed3074d2 # v25.4.0
+      image: ghcr.io/ansible/ansible-devspaces@sha256:0abc9ac0b060c2f8703be1ffc143311e28da969e87346fd15f76c3380e115577
       memoryRequest: 256M
       memoryLimit: 6Gi
       cpuRequest: 250m


### PR DESCRIPTION
This PR updates the ansible-devspaces container image SHA to the latest.