### PR TITLE
Update ansible-devspaces container image

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -5,7 +5,7 @@ metadata:
 components:
   - name: tooling-container
     container:
-      image: ghcr.io/ansible/ansible-devspaces@sha256:7cf40941f4082f4afb171269214776bb5b0d859cc7793f9f51bfec95ed3074d2 # v25.4.0
+      image: ghcr.io/ansible/ansible-devspaces@sha256:3857de7d39293c1a033a6faa3ef836a34863339a1c4eefd74b8bb4fe645bbc88
       memoryRequest: 256M
       memoryLimit: 6Gi
       cpuRequest: 250m


### PR DESCRIPTION
This PR updates the ansible-devspaces container image SHA to the latest.