### PR TITLE
fix: bypass cluster proxy for molecule k8s API calls in air-gapped environments

### DIFF
--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/default/create.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/default/create.yml
@@ -12,6 +12,13 @@
         state: present
         definition: "{{ lookup('template', 'templates/deployment.yml') | from_yaml }}"
         wait: true
+      environment:
+        http_proxy: ""
+        https_proxy: ""
+        HTTP_PROXY: ""
+        HTTPS_PROXY: ""
+        NO_PROXY: "*"
+        no_proxy: "*"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
 

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/default/destroy.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/default/destroy.yml
@@ -13,6 +13,13 @@
         state: absent
         definition: "{{ lookup('template', 'templates/deployment.yml') | from_yaml }}"
         wait: true
+      environment:
+        http_proxy: ""
+        https_proxy: ""
+        HTTP_PROXY: ""
+        HTTPS_PROXY: ""
+        NO_PROXY: "*"
+        no_proxy: "*"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
 


### PR DESCRIPTION
Clear `HTTP_PROXY`/`HTTPS_PROXY` and set `NO_PROXY=*` on the `community.okd.k8s` tasks in molecule `create.yml` and `destroy.yml` so the Python kubernetes client connects directly to the internal Kubernetes API instead of routing through the cluster-wide proxy.

Related issue: https://redhat.atlassian.net/browse/CRW-9963